### PR TITLE
[minor] Add structured exception hierarchy (netimate.errors)

### DIFF
--- a/.importlinter.ini
+++ b/.importlinter.ini
@@ -15,6 +15,8 @@ layers =
     netimate.infrastructure
     netimate.core
     netimate.interfaces
+    netimate.errors
+
 
 # ────────────────────────────────────────────────────────────────
 # 2. View isolation
@@ -154,3 +156,19 @@ exclude_modules =
     netimate.interfaces.*
     netimate.infrastructure
     netimate.infrastructure.*
+
+# ────────────────────────────────────────────────────────────────
+# 8. Prevent error module importing any other code
+# ────────────────────────────────────────────────────────────────
+[importlinter:contract:no_internal_imports_in_errors]
+name = Errors module must not import other Netimate packages
+type = forbidden
+source_modules = netimate.errors
+forbidden_modules =
+    netimate.application
+    netimate.core
+    netimate.infrastructure
+    netimate.interfaces
+    netimate.plugins
+    netimate.view
+

--- a/netimate/errors/__init__.py
+++ b/netimate/errors/__init__.py
@@ -1,0 +1,24 @@
+"""Top‑level re‑exports for Netimate's custom exception hierarchy."""
+from __future__ import annotations
+
+from .base import NetimateError
+from .cli import CliUsageError
+from .command import CommandError
+from .config import ConfigError
+from .connection import ConnectionProtocolError, AuthError, ConnectionTimeoutError
+from .plugin import PluginError
+from .runner import RunnerError
+from .shell import ShellRuntimeError
+
+__all__ = [
+    "NetimateError",
+    "CliUsageError",
+    "CommandError",
+    "ConfigError",
+    "ConnectionProtocolError",
+    "AuthError",
+    "ConnectionTimeoutError",
+    "PluginError",
+    "RunnerError",
+    "ShellRuntimeError"
+]

--- a/netimate/errors/__init__.py
+++ b/netimate/errors/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .application import ApplicationError
 from .base import NetimateError
 from .cli import CliUsageError
 from .command import CommandError
@@ -22,4 +23,5 @@ __all__ = [
     "PluginError",
     "RunnerError",
     "ShellRuntimeError",
+    "ApplicationError",
 ]

--- a/netimate/errors/__init__.py
+++ b/netimate/errors/__init__.py
@@ -1,11 +1,12 @@
 """Top‑level re‑exports for Netimate's custom exception hierarchy."""
+
 from __future__ import annotations
 
 from .base import NetimateError
 from .cli import CliUsageError
 from .command import CommandError
 from .config import ConfigError
-from .connection import ConnectionProtocolError, AuthError, ConnectionTimeoutError
+from .connection import AuthError, ConnectionProtocolError, ConnectionTimeoutError
 from .plugin import PluginError
 from .runner import RunnerError
 from .shell import ShellRuntimeError
@@ -20,5 +21,5 @@ __all__ = [
     "ConnectionTimeoutError",
     "PluginError",
     "RunnerError",
-    "ShellRuntimeError"
+    "ShellRuntimeError",
 ]

--- a/netimate/errors/application.py
+++ b/netimate/errors/application.py
@@ -1,0 +1,8 @@
+# netimate/errors/application.py
+from .base import NetimateError
+
+
+class ApplicationError(NetimateError):
+    """Raised when the application layer cannot fulfil a user request."""
+
+    default_message = "Application-level failure"

--- a/netimate/errors/base.py
+++ b/netimate/errors/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+class NetimateError(Exception):
+    """Base class for **all** Netimate‑specific exceptions.
+
+    Catch this to handle any user‑facing error in a single place::
+
+        try:
+            netimate.run(...)
+        except NetimateError as err:
+            print(err)
+    """
+
+    default_message: str = "An unknown Netimate error occurred."
+
+    def __init__(self, message: str | None = None, *, cause: Exception | None = None) -> None:
+        if message is None:
+            message = self.default_message
+        super().__init__(message)
+        # Preserve the original stack if provided
+        if cause is not None:
+            self.__cause__ = cause

--- a/netimate/errors/cli.py
+++ b/netimate/errors/cli.py
@@ -1,4 +1,5 @@
 """CLI‑specific usage errors."""
+
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/errors/cli.py
+++ b/netimate/errors/cli.py
@@ -1,0 +1,10 @@
+"""CLI‑specific usage errors."""
+from __future__ import annotations
+
+from .base import NetimateError
+
+
+class CliUsageError(NetimateError):
+    """Raised for incorrect CLI invocation (invalid flags, arguments, etc.)."""
+
+    default_message = "Invalid CLI usage"

--- a/netimate/errors/command.py
+++ b/netimate/errors/command.py
@@ -1,4 +1,5 @@
 """Errors related to executing device commands."""
+
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/errors/command.py
+++ b/netimate/errors/command.py
@@ -1,0 +1,10 @@
+"""Errors related to executing device commands."""
+from __future__ import annotations
+
+from .base import NetimateError
+
+
+class CommandError(NetimateError):
+    """Raised when a device command cannot be executed or parsed."""
+
+    default_message = "Failed to execute command on device"

--- a/netimate/errors/config.py
+++ b/netimate/errors/config.py
@@ -1,4 +1,5 @@
 """Configuration‑related errors."""
+
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/errors/config.py
+++ b/netimate/errors/config.py
@@ -1,0 +1,10 @@
+"""Configuration‑related errors."""
+from __future__ import annotations
+
+from .base import NetimateError
+
+
+class ConfigError(NetimateError):
+    """Raised when configuration files are missing, malformed or invalid."""
+
+    default_message = "Configuration error"

--- a/netimate/errors/connection.py
+++ b/netimate/errors/connection.py
@@ -1,0 +1,22 @@
+"""Connection‑level errors (SSH, Telnet, NETCONF, etc.)."""
+from __future__ import annotations
+
+from .base import NetimateError
+
+
+class ConnectionProtocolError(NetimateError):
+    """General transport or session failure."""
+
+    default_message = "Connection to device failed"
+
+
+class AuthError(ConnectionProtocolError):
+    """Authentication failure."""
+
+    default_message = "Authentication failed"
+
+
+class ConnectionTimeoutError(ConnectionProtocolError):
+    """Operation timed out."""
+
+    default_message = "Connection timed out"

--- a/netimate/errors/connection.py
+++ b/netimate/errors/connection.py
@@ -1,4 +1,5 @@
 """Connection‑level errors (SSH, Telnet, NETCONF, etc.)."""
+
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/errors/plugin.py
+++ b/netimate/errors/plugin.py
@@ -1,4 +1,5 @@
 """Plugin discovery and loading errors."""
+
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/errors/plugin.py
+++ b/netimate/errors/plugin.py
@@ -1,0 +1,10 @@
+"""Plugin discovery and loading errors."""
+from __future__ import annotations
+
+from .base import NetimateError
+
+
+class PluginError(NetimateError):
+    """Raised when a plugin cannot be found, loaded or initialised."""
+
+    default_message = "Plugin system error"

--- a/netimate/errors/runner.py
+++ b/netimate/errors/runner.py
@@ -1,0 +1,10 @@
+"""High‑level runner / orchestration errors."""
+from __future__ import annotations
+
+from .base import NetimateError
+
+
+class RunnerError(NetimateError):
+    """Raised when multi‑device orchestration fails."""
+
+    default_message = "Runner failed to complete task"

--- a/netimate/errors/runner.py
+++ b/netimate/errors/runner.py
@@ -1,4 +1,5 @@
 """High‑level runner / orchestration errors."""
+
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/errors/shell.py
+++ b/netimate/errors/shell.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from .base import NetimateError
 
 

--- a/netimate/errors/shell.py
+++ b/netimate/errors/shell.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+from .base import NetimateError
+
+
+class ShellRuntimeError(NetimateError):
+    """Raised when a command entered the interactive shell fails at runtime."""
+
+    default_message = "Shell command failed"

--- a/tests/unit/test_errors/test_defaults.py
+++ b/tests/unit/test_errors/test_defaults.py
@@ -16,6 +16,7 @@ from netimate import errors
         (errors.RunnerError, "Runner failed to complete task"),
         (errors.CliUsageError, "Invalid CLI usage"),
         (errors.ShellRuntimeError, "Shell command failed"),
+        (errors.ApplicationError, "Application-level failure"),
     ],
 )
 def test_default_message(exc_cls, expected):

--- a/tests/unit/test_errors/test_defaults.py
+++ b/tests/unit/test_errors/test_defaults.py
@@ -1,0 +1,23 @@
+import pytest
+
+from netimate import errors
+
+
+@pytest.mark.parametrize(
+    "exc_cls, expected",
+    [
+        (errors.NetimateError, "An unknown Netimate error occurred."),
+        (errors.ConfigError, "Configuration error"),
+        (errors.PluginError, "Plugin system error"),
+        (errors.ConnectionProtocolError, "Connection to device failed"),
+        (errors.AuthError, "Authentication failed"),
+        (errors.ConnectionTimeoutError, "Connection timed out"),
+        (errors.CommandError, "Failed to execute command on device"),
+        (errors.RunnerError, "Runner failed to complete task"),
+        (errors.CliUsageError, "Invalid CLI usage"),
+        (errors.ShellRuntimeError, "Shell command failed"),
+    ],
+)
+def test_default_message(exc_cls, expected):
+    err = exc_cls()
+    assert str(err) == expected


### PR DESCRIPTION
This PR introduces a structured, centralized exception hierarchy for Netimate under the new netimate.errors package. It defines clear error types for all major functional areas of the system (CLI, shell, plugins, connection, config, etc.) and provides a consistent base class, NetimateError, for safe error handling across all layers.

No behavioural changes are introduced in this PR — this is strictly scaffolding for use in future refactors.