### PR TITLE
[patch] Raise RegistryError for missing plugins

### DIFF
--- a/netimate/core/plugin_engine/plugin_registry.py
+++ b/netimate/core/plugin_engine/plugin_registry.py
@@ -2,6 +2,7 @@
 from enum import Enum
 from typing import Callable, Dict, Type
 
+from netimate.errors import RegistryError
 from netimate.interfaces.core.registry import PluginRegistryInterface
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.interfaces.plugin.device_command import DeviceCommand
@@ -30,9 +31,9 @@ class PluginRegistry(PluginRegistryInterface):
     """
 
     def __init__(self):
-        self.device_commands: Dict[str, Type[DeviceCommand]] = {}
-        self.protocols: Dict[str, Type[ConnectionProtocol]] = {}
-        self.repositories: Dict[str, Type[DeviceRepository]] = {}
+        self._device_commands: Dict[str, Type[DeviceCommand]] = {}
+        self._protocols: Dict[str, Type[ConnectionProtocol]] = {}
+        self._repositories: Dict[str, Type[DeviceRepository]] = {}
 
         self._handlers: Dict[PluginKind, Callable] = {
             PluginKind.DEVICE_COMMAND: self.register_device_command,
@@ -48,36 +49,48 @@ class PluginRegistry(PluginRegistryInterface):
 
     def register_device_command(self, name: str, command_cls: Type[DeviceCommand]):
         """Register a DeviceCommand implementation under *name*."""
-        self.device_commands[name] = command_cls
+        self._device_commands[name] = command_cls
 
     def register_protocol(self, name: str, protocol_cls: Type[ConnectionProtocol]):
         """Register a ConnectionProtocol implementation under *name*."""
-        self.protocols[name] = protocol_cls
+        self._protocols[name] = protocol_cls
 
     def register_device_repository(self, name: str, repo_cls: Type[DeviceRepository]):
         """Register a DeviceRepository implementation under *name*."""
-        self.repositories[name] = repo_cls
+        self._repositories[name] = repo_cls
 
     def get_device_command(self, name: str) -> Type[DeviceCommand]:
         """Return the DeviceCommand class registered under *name*."""
-        return self.device_commands[name]
+        try:
+            return self._device_commands[name]
+        except KeyError as e:
+            raise RegistryError(
+                f"No device command plugin named '{name}' is registered."
+            ) from e
 
-    def get_protocol(self, name: str) -> Type[ConnectionProtocol]:
-        """Return the ConnectionProtocol class registered under *name*."""
-        return self.protocols[name]
+    def get_protocol(self, name: str) -> type:
+        try:
+            return self._protocols[name]
+        except KeyError as e:
+            raise RegistryError(
+                f"No connection protocol plugin named '{name}' is registered."
+            ) from e
 
     def get_device_repository(self, name: str) -> Type[DeviceRepository]:
         """Return the DeviceRepository class registered under *name*."""
-        return self.repositories[name]
+        try:
+            return self._repositories[name]
+        except KeyError as e:
+            raise RegistryError(f"No repository plugin named '{name}' is registered.") from e
 
     def all_device_commands(self):
         """Return all registered device command names."""
-        return self.device_commands.keys()
+        return self._device_commands.keys()
 
     def all_device_repositories(self):
         """Return all registered device repository names."""
-        return self.repositories.keys()
+        return self._repositories.keys()
 
     def all_protocols(self):
         """Return all registered protocol names."""
-        return self.protocols.keys()
+        return self._protocols.keys()

--- a/netimate/core/plugin_engine/plugin_registry.py
+++ b/netimate/core/plugin_engine/plugin_registry.py
@@ -64,9 +64,7 @@ class PluginRegistry(PluginRegistryInterface):
         try:
             return self._device_commands[name]
         except KeyError as e:
-            raise RegistryError(
-                f"No device command plugin named '{name}' is registered."
-            ) from e
+            raise RegistryError(f"No device command plugin named '{name}' is registered.") from e
 
     def get_protocol(self, name: str) -> type:
         try:

--- a/netimate/errors/__init__.py
+++ b/netimate/errors/__init__.py
@@ -8,7 +8,7 @@ from .cli import CliUsageError
 from .command import CommandError
 from .config import ConfigError
 from .connection import AuthError, ConnectionProtocolError, ConnectionTimeoutError
-from .plugin import PluginError
+from .registry import RegistryError
 from .runner import RunnerError
 from .shell import ShellRuntimeError
 
@@ -20,7 +20,7 @@ __all__ = [
     "ConnectionProtocolError",
     "AuthError",
     "ConnectionTimeoutError",
-    "PluginError",
+    "RegistryError",
     "RunnerError",
     "ShellRuntimeError",
     "ApplicationError",

--- a/netimate/errors/registry.py
+++ b/netimate/errors/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from .base import NetimateError
 
 
-class PluginError(NetimateError):
+class RegistryError(NetimateError):
     """Raised when a plugin cannot be found, loaded or initialised."""
 
     default_message = "Plugin system error"

--- a/tests/unit/test_application/test_application.py
+++ b/tests/unit/test_application/test_application.py
@@ -8,6 +8,7 @@ import pytest
 from netimate.application.application import Application
 from netimate.composition import composition_root
 from netimate.core.plugin_engine.plugin_registry import PluginRegistry
+from netimate.errors import RegistryError
 
 
 def test_list_usage(app_with_mock_command_repo_registry):
@@ -121,7 +122,7 @@ async def test_bad_command():
         template_provider=MagicMock(),
     )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(RegistryError):
         await app.run_device_command(device_names=["r1"], command_name="no-such-cmd")
 
 

--- a/tests/unit/test_core/test_registry.py
+++ b/tests/unit/test_core/test_registry.py
@@ -38,8 +38,9 @@ def test_register_unknown_kind_raises():
 def test_missing_plugin_raises_registry_error():
     registry = PluginRegistry()
 
-    with pytest.raises(RegistryError, match=f"No device command plugin named 'dummy' is "
-                                            f"registered."):
+    with pytest.raises(
+        RegistryError, match="No device command plugin named 'dummy' is registered."
+    ):
         registry.get_device_command("dummy")
 
     with pytest.raises(RegistryError, match="No connection protocol plugin named 'dummy'"):

--- a/tests/unit/test_core/test_registry.py
+++ b/tests/unit/test_core/test_registry.py
@@ -2,6 +2,7 @@
 import pytest
 
 from netimate.core.plugin_engine.plugin_registry import PluginKind, PluginRegistry
+from netimate.errors import RegistryError
 
 
 class DummyPlugin:
@@ -32,3 +33,17 @@ def test_register_unknown_kind_raises():
     registry = PluginRegistry()
     with pytest.raises(ValueError):
         registry.register("not-a-kind", "dummy", DummyPlugin)  # type: ignore
+
+
+def test_missing_plugin_raises_registry_error():
+    registry = PluginRegistry()
+
+    with pytest.raises(RegistryError, match=f"No device command plugin named 'dummy' is "
+                                            f"registered."):
+        registry.get_device_command("dummy")
+
+    with pytest.raises(RegistryError, match="No connection protocol plugin named 'dummy'"):
+        registry.get_protocol("dummy")
+
+    with pytest.raises(RegistryError, match="No repository plugin named 'dummy'"):
+        registry.get_device_repository("dummy")

--- a/tests/unit/test_errors/test_defaults.py
+++ b/tests/unit/test_errors/test_defaults.py
@@ -8,7 +8,7 @@ from netimate import errors
     [
         (errors.NetimateError, "An unknown Netimate error occurred."),
         (errors.ConfigError, "Configuration error"),
-        (errors.PluginError, "Plugin system error"),
+        (errors.RegistryError, "Plugin system error"),
         (errors.ConnectionProtocolError, "Connection to device failed"),
         (errors.AuthError, "Authentication failed"),
         (errors.ConnectionTimeoutError, "Connection timed out"),


### PR DESCRIPTION
This PR updates the PluginRegistry to raise a structured RegistryError when a plugin is not found, replacing raw KeyError exceptions.

Changes:
	•	Introduced RegistryError in netimate.errors
	•	Updated get_protocol(), get_device_command(), and get_device_repository() to raise RegistryError on lookup failure
	•	Added tests for missing plugin scenarios

No behavioural changes for successful paths.