### PR TITLE
[patch] Enforce protocol error contract across connection plugins

### DIFF
--- a/netimate/errors/__init__.py
+++ b/netimate/errors/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """Top‑level re‑exports for Netimate's custom exception hierarchy."""
 
 from __future__ import annotations

--- a/netimate/errors/application.py
+++ b/netimate/errors/application.py
@@ -1,4 +1,4 @@
-# netimate/errors/application.py
+# SPDX-License-Identifier: MPL-2.0
 from .base import NetimateError
 
 

--- a/netimate/errors/base.py
+++ b/netimate/errors/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 

--- a/netimate/errors/cli.py
+++ b/netimate/errors/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """CLI‑specific usage errors."""
 
 from __future__ import annotations

--- a/netimate/errors/command.py
+++ b/netimate/errors/command.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """Errors related to executing device commands."""
 
 from __future__ import annotations

--- a/netimate/errors/config.py
+++ b/netimate/errors/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """Configuration‑related errors."""
 
 from __future__ import annotations

--- a/netimate/errors/connection.py
+++ b/netimate/errors/connection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """Connection‑level errors (SSH, Telnet, NETCONF, etc.)."""
 
 from __future__ import annotations

--- a/netimate/errors/registry.py
+++ b/netimate/errors/registry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """Plugin discovery and loading errors."""
 
 from __future__ import annotations

--- a/netimate/errors/runner.py
+++ b/netimate/errors/runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 """High‑level runner / orchestration errors."""
 
 from __future__ import annotations

--- a/netimate/errors/shell.py
+++ b/netimate/errors/shell.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
 from .base import NetimateError

--- a/netimate/interfaces/plugin/connection_protocol.py
+++ b/netimate/interfaces/plugin/connection_protocol.py
@@ -7,14 +7,12 @@ Abstract base plugin class for any interactive connection mechanism
 implementations are loaded at runtime by the PluginRegistry and used by
 the Runner to execute device commands.
 """
+import inspect
 from abc import abstractmethod
+from functools import wraps
 from typing import Dict
 
-import inspect
-from functools import wraps
-
-from netimate.errors import NetimateError, ConnectionProtocolError
-
+from netimate.errors import ConnectionProtocolError, NetimateError
 from netimate.interfaces.plugin.plugin import Plugin
 from netimate.models.device import Device
 
@@ -27,6 +25,7 @@ def _wrap_netimate_errors(fn):
     above ConnectionProtocol never see third‑party tracebacks.
     """
     if inspect.iscoroutinefunction(fn):
+
         @wraps(fn)
         async def async_wrapper(*args, **kwargs):
             try:
@@ -35,8 +34,10 @@ def _wrap_netimate_errors(fn):
                 raise
             except Exception as err:  # pylint: disable=broad-except
                 raise ConnectionProtocolError("Unhandled protocol error") from err
+
         return async_wrapper
     else:
+
         @wraps(fn)
         def sync_wrapper(*args, **kwargs):
             try:
@@ -45,6 +46,7 @@ def _wrap_netimate_errors(fn):
                 raise
             except Exception as err:  # pylint: disable=broad-except
                 raise ConnectionProtocolError("Unhandled protocol error") from err
+
         return sync_wrapper
 
 

--- a/netimate/interfaces/plugin/connection_protocol.py
+++ b/netimate/interfaces/plugin/connection_protocol.py
@@ -10,19 +10,70 @@ the Runner to execute device commands.
 from abc import abstractmethod
 from typing import Dict
 
+import inspect
+from functools import wraps
+
+from netimate.errors import NetimateError, ConnectionProtocolError
+
 from netimate.interfaces.plugin.plugin import Plugin
 from netimate.models.device import Device
+
+
+def _wrap_netimate_errors(fn):
+    """
+    Ensure only NetimateError (or subclasses) exit the function.
+
+    Any other exception is wrapped in ConnectionProtocolError so that layers
+    above ConnectionProtocol never see third‑party tracebacks.
+    """
+    if inspect.iscoroutinefunction(fn):
+        @wraps(fn)
+        async def async_wrapper(*args, **kwargs):
+            try:
+                return await fn(*args, **kwargs)
+            except NetimateError:
+                raise
+            except Exception as err:  # pylint: disable=broad-except
+                raise ConnectionProtocolError("Unhandled protocol error") from err
+        return async_wrapper
+    else:
+        @wraps(fn)
+        def sync_wrapper(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except NetimateError:
+                raise
+            except Exception as err:  # pylint: disable=broad-except
+                raise ConnectionProtocolError("Unhandled protocol error") from err
+        return sync_wrapper
 
 
 class ConnectionProtocol(Plugin):  # pragma: no cover
     """
     Base class for all connection‑oriented plugins.
 
-    Lifecycle:
+    Contract
+    --------
+    * ``connect``, ``send_command`` and ``disconnect`` must raise only
+      :class:`netimate.errors.NetimateError` (or subclasses) on failure.
+    * Any other exception will be wrapped automatically in
+      :class:`netimate.errors.ConnectionProtocolError` at runtime (enforced
+      via ``__init_subclass__``).
+
+    Lifecycle
+    ---------
     1. ``connect``     – open transport / login
     2. ``send_command`` – execute a single command string
     3. ``disconnect``  – cleanly close the session
     """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # Automatically wrap core public methods so subclasses can't leak
+        # external exceptions.
+        for _name in ("connect", "send_command", "disconnect"):
+            if hasattr(cls, _name):
+                setattr(cls, _name, _wrap_netimate_errors(getattr(cls, _name)))
 
     @abstractmethod
     def __init__(self, device: Device, plugin_settings: Dict | None = None):

--- a/netimate/plugins/connection_protocols/netmiko/ssh.py
+++ b/netimate/plugins/connection_protocols/netmiko/ssh.py
@@ -10,18 +10,17 @@ supported by Netmiko but not yet by Scrapli.
 import asyncio
 import logging
 
-from netmiko import ConnectHandler
 from netmiko import (
+    ConnectHandler,
     NetmikoAuthenticationException,
     NetmikoTimeoutException,
 )
 
 from netimate.errors import (
     AuthError,
-    ConnectionTimeoutError,
     ConnectionProtocolError,
+    ConnectionTimeoutError,
 )
-
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.models.device import Device
 

--- a/netimate/plugins/connection_protocols/netmiko/ssh.py
+++ b/netimate/plugins/connection_protocols/netmiko/ssh.py
@@ -11,6 +11,16 @@ import asyncio
 import logging
 
 from netmiko import ConnectHandler
+from netmiko import (
+    NetmikoAuthenticationException,
+    NetmikoTimeoutException,
+)
+
+from netimate.errors import (
+    AuthError,
+    ConnectionTimeoutError,
+    ConnectionProtocolError,
+)
 
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.models.device import Device
@@ -47,27 +57,43 @@ class NetmikoSSHConnectionProtocol(ConnectionProtocol):
         """Open a Netmiko SSH session asynchronously."""
         loop = asyncio.get_running_loop()
         logger.info(f"Connecting to {self.device.host} via SSH")
-        self.connection = await loop.run_in_executor(
-            None,
-            lambda: ConnectHandler(
-                device_type="cisco_ios",
-                host=self.device.host,
-                username=self.device.username,
-                password=self.device.password,
-            ),
-        )
+        try:
+            self.connection = await loop.run_in_executor(
+                None,
+                lambda: ConnectHandler(
+                    device_type="cisco_ios",
+                    host=self.device.host,
+                    username=self.device.username,
+                    password=self.device.password,
+                ),
+            )
+        except NetmikoAuthenticationException as err:
+            raise AuthError() from err
+        except NetmikoTimeoutException as err:
+            raise ConnectionTimeoutError() from err
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Unexpected connection error") from err
 
     async def send_command(self, command: str) -> str:
         """Send *command* over the established SSH connection."""
         loop = asyncio.get_running_loop()
-        logger.info(f"Sending command over SSH: {command}")
         if self.connection is None:
-            raise RuntimeError("Connection not established")
+            raise ConnectionProtocolError("Connection not established")
 
-        return await loop.run_in_executor(None, self.connection.send_command, command)
+        try:
+            logger.info(f"Sending command over SSH: {command}")
+            return await loop.run_in_executor(None, self.connection.send_command, command)
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Failed to execute command") from err
 
     async def disconnect(self):
         """Cleanly close the Netmiko SSH session."""
+        if self.connection is None:
+            return  # nothing to do
+
         loop = asyncio.get_running_loop()
-        logger.info(f"Disconnecting from {self.device.host}")
-        await loop.run_in_executor(None, self.connection.disconnect)
+        try:
+            logger.info(f"Disconnecting from {self.device.host}")
+            await loop.run_in_executor(None, self.connection.disconnect)
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Failed to disconnect") from err

--- a/netimate/plugins/connection_protocols/netmiko/telnet.py
+++ b/netimate/plugins/connection_protocols/netmiko/telnet.py
@@ -9,18 +9,17 @@ legacy devices that only expose a Telnet management channel.
 import asyncio
 import logging
 
-from netmiko import ConnectHandler
 from netmiko import (
+    ConnectHandler,
     NetmikoAuthenticationException,
     NetmikoTimeoutException,
 )
 
 from netimate.errors import (
     AuthError,
-    ConnectionTimeoutError,
     ConnectionProtocolError,
+    ConnectionTimeoutError,
 )
-
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.models.device import Device
 

--- a/netimate/plugins/connection_protocols/netmiko/telnet.py
+++ b/netimate/plugins/connection_protocols/netmiko/telnet.py
@@ -10,6 +10,16 @@ import asyncio
 import logging
 
 from netmiko import ConnectHandler
+from netmiko import (
+    NetmikoAuthenticationException,
+    NetmikoTimeoutException,
+)
+
+from netimate.errors import (
+    AuthError,
+    ConnectionTimeoutError,
+    ConnectionProtocolError,
+)
 
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.models.device import Device
@@ -40,27 +50,43 @@ class NetmikoTelnetConnectionProtocol(ConnectionProtocol):
         """Open a Netmiko Telnet session asynchronously."""
         loop = asyncio.get_running_loop()
         logger.info(f"Connecting to {self.device.host} via Telnet")
-        self.connection = await loop.run_in_executor(
-            None,
-            lambda: ConnectHandler(
-                device_type="cisco_ios_telnet",
-                host=self.device.host,
-                username=self.device.username,
-                password=self.device.password,
-            ),
-        )
+        try:
+            self.connection = await loop.run_in_executor(
+                None,
+                lambda: ConnectHandler(
+                    device_type="cisco_ios_telnet",
+                    host=self.device.host,
+                    username=self.device.username,
+                    password=self.device.password,
+                ),
+            )
+        except NetmikoAuthenticationException as err:
+            raise AuthError() from err
+        except NetmikoTimeoutException as err:
+            raise ConnectionTimeoutError() from err
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Unexpected connection error") from err
 
     async def send_command(self, command: str) -> str:
         """Send *command* over the Telnet session."""
         loop = asyncio.get_running_loop()
-        logger.info(f"Sending command over Telnet: {command}")
         if self.connection is None:
-            raise RuntimeError("Connection not established")
+            raise ConnectionProtocolError("Connection not established")
 
-        return await loop.run_in_executor(None, self.connection.send_command, command)
+        try:
+            logger.info(f"Sending command over Telnet: {command}")
+            return await loop.run_in_executor(None, self.connection.send_command, command)
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Failed to execute command") from err
 
     async def disconnect(self):
         """Close the Telnet session."""
+        if self.connection is None:
+            return
+
         loop = asyncio.get_running_loop()
-        logger.info(f"Disconnecting from {self.device.host}")
-        await loop.run_in_executor(None, self.connection.disconnect)
+        try:
+            logger.info(f"Disconnecting from {self.device.host}")
+            await loop.run_in_executor(None, self.connection.disconnect)
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Failed to disconnect") from err

--- a/netimate/plugins/connection_protocols/scrapli/asyncssh.py
+++ b/netimate/plugins/connection_protocols/scrapli/asyncssh.py
@@ -29,10 +29,9 @@ from scrapli.exceptions import (
 
 from netimate.errors import (
     AuthError,
-    ConnectionTimeoutError,
     ConnectionProtocolError,
+    ConnectionTimeoutError,
 )
-
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.models.device import Device
 

--- a/netimate/plugins/connection_protocols/scrapli/asyncssh.py
+++ b/netimate/plugins/connection_protocols/scrapli/asyncssh.py
@@ -20,6 +20,19 @@ from scrapli.driver.core import (
 )
 from scrapli.driver.generic import AsyncGenericDriver
 
+# Additional imports for error handling
+from scrapli.exceptions import (
+    ScrapliAuthenticationFailed,
+    ScrapliConnectionError,
+    ScrapliTimeout,
+)
+
+from netimate.errors import (
+    AuthError,
+    ConnectionTimeoutError,
+    ConnectionProtocolError,
+)
+
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.models.device import Device
 
@@ -83,13 +96,34 @@ class ScrapliAsyncsshConnectionProtocol(ConnectionProtocol):
             ssh_known_hosts_file=known_hosts_file,
         )
 
-        await self.client.open()
+        try:
+            await self.client.open()
+        except ScrapliAuthenticationFailed as err:
+            raise AuthError() from err
+        except ScrapliTimeout as err:
+            raise ConnectionTimeoutError() from err
+        except ScrapliConnectionError as err:
+            raise ConnectionProtocolError("Connection failed") from err
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Unexpected connection error") from err
 
     async def send_command(self, command: str) -> str:
         if not self.client:
-            raise ValueError("No connection established! Call .connect()")
-        response = await self.client.send_command(command)
-        return response.result
+            raise ConnectionProtocolError("No connection established; call .connect() first")
+
+        try:
+            response = await self.client.send_command(command)
+            return response.result
+        except ScrapliTimeout as err:
+            raise ConnectionTimeoutError() from err
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Failed to execute command") from err
 
     async def disconnect(self):
-        await self.client.close()
+        if not self.client:
+            return
+
+        try:
+            await self.client.close()
+        except Exception as err:  # pylint: disable=broad-except
+            raise ConnectionProtocolError("Failed to disconnect") from err

--- a/tests/unit/test_plugins/test_netmiko_ssh_connection_protocol.py
+++ b/tests/unit/test_plugins/test_netmiko_ssh_connection_protocol.py
@@ -2,17 +2,16 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from netmiko import (
     NetmikoAuthenticationException,
     NetmikoTimeoutException,
 )
+
 from netimate.errors import (
     AuthError,
-    ConnectionTimeoutError,
     ConnectionProtocolError,
+    ConnectionTimeoutError,
 )
-
 from netimate.models.device import Device
 from netimate.plugins.connection_protocols.netmiko.ssh import NetmikoSSHConnectionProtocol
 

--- a/tests/unit/test_plugins/test_netmiko_ssh_connection_protocol.py
+++ b/tests/unit/test_plugins/test_netmiko_ssh_connection_protocol.py
@@ -3,6 +3,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from netmiko import (
+    NetmikoAuthenticationException,
+    NetmikoTimeoutException,
+)
+from netimate.errors import (
+    AuthError,
+    ConnectionTimeoutError,
+    ConnectionProtocolError,
+)
+
 from netimate.models.device import Device
 from netimate.plugins.connection_protocols.netmiko.ssh import NetmikoSSHConnectionProtocol
 
@@ -32,3 +42,60 @@ async def test_ssh_protocol_runs_command(mock_connect_handler):
     assert output == "mocked output"
     mock_connection.send_command.assert_called_once_with("show version")
     mock_connection.disconnect.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("netimate.plugins.connection_protocols.netmiko.ssh.ConnectHandler")
+async def test_ssh_auth_failure_raises_auth_error(mock_connect_handler):
+    mock_connect_handler.side_effect = NetmikoAuthenticationException("bad creds")
+
+    device = Device(
+        name="router1",
+        host="10.0.0.1",
+        username="admin",
+        password="wrong",
+        protocol="ssh",
+        platform="fake",
+    )
+    protocol = NetmikoSSHConnectionProtocol(device)
+
+    with pytest.raises(AuthError):
+        await protocol.connect()
+
+
+@pytest.mark.asyncio
+@patch("netimate.plugins.connection_protocols.netmiko.ssh.ConnectHandler")
+async def test_ssh_timeout_raises_timeout_error(mock_connect_handler):
+    mock_connect_handler.side_effect = NetmikoTimeoutException("timeout")
+
+    device = Device(
+        name="router1",
+        host="10.0.0.1",
+        username="admin",
+        password="admin",
+        protocol="ssh",
+        platform="fake",
+    )
+    protocol = NetmikoSSHConnectionProtocol(device)
+
+    with pytest.raises(ConnectionTimeoutError):
+        await protocol.connect()
+
+
+@pytest.mark.asyncio
+@patch("netimate.plugins.connection_protocols.netmiko.ssh.ConnectHandler")
+async def test_ssh_unexpected_exception_is_wrapped(mock_connect_handler):
+    mock_connect_handler.side_effect = RuntimeError("boom")
+
+    device = Device(
+        name="router1",
+        host="10.0.0.1",
+        username="admin",
+        password="admin",
+        protocol="ssh",
+        platform="fake",
+    )
+    protocol = NetmikoSSHConnectionProtocol(device)
+
+    with pytest.raises(ConnectionProtocolError):
+        await protocol.connect()

--- a/tests/unit/test_plugins/test_netmiko_telnet_connection_protocol.py
+++ b/tests/unit/test_plugins/test_netmiko_telnet_connection_protocol.py
@@ -2,18 +2,17 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from netimate.plugins.connection_protocols.netmiko.telnet import NetmikoTelnetConnectionProtocol
-
 from netmiko import (
     NetmikoAuthenticationException,
     NetmikoTimeoutException,
 )
+
 from netimate.errors import (
     AuthError,
-    ConnectionTimeoutError,
     ConnectionProtocolError,
+    ConnectionTimeoutError,
 )
+from netimate.plugins.connection_protocols.netmiko.telnet import NetmikoTelnetConnectionProtocol
 
 
 @patch("netimate.plugins.connection_protocols.netmiko.telnet.ConnectHandler")

--- a/tests/unit/test_plugins/test_scrapli_asyncssh_connection_protocol.py
+++ b/tests/unit/test_plugins/test_scrapli_asyncssh_connection_protocol.py
@@ -3,15 +3,13 @@ from os.path import expanduser
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from scrapli.exceptions import ScrapliAuthenticationFailed, ScrapliTimeout
 
+from netimate.errors import AuthError, ConnectionProtocolError, ConnectionTimeoutError
 from netimate.plugins.connection_protocols.scrapli.asyncssh import (
     PLATFORM_DRIVERS,
     ScrapliAsyncsshConnectionProtocol,
 )
-
-from scrapli.exceptions import ScrapliAuthenticationFailed, ScrapliTimeout
-
-from netimate.errors import AuthError, ConnectionTimeoutError, ConnectionProtocolError
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Applied interface-level error contract to ConnectionProtocol
- Updated Netmiko SSH and Telnet plugins to raise structured Netimate errors (AuthError, ConnectionTimeoutError, ConnectionProtocolError)
- Updated Scrapli async plugin to conform to the same contract
- Added test coverage for all mapped error scenarios across plugins

Note: While these changes are tagged as patch releases, they represent progressive work under the broader 0.4.x error-handling milestone. No breaking changes are introduced.