### PR TITLE
[minor] Extract Snapshot and Command Execution into Application Services

### DIFF
--- a/netimate/application/application.py
+++ b/netimate/application/application.py
@@ -14,7 +14,6 @@ call the same `Application` façade.
 """
 
 import logging
-from datetime import datetime
 from difflib import unified_diff
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -27,9 +26,7 @@ from netimate.interfaces.core.registry import PluginRegistryInterface
 from netimate.interfaces.core.runner import RunnerInterface
 from netimate.interfaces.infrastructure.settings import SettingsInterface
 from netimate.interfaces.infrastructure.template_provider import TemplateProviderInterface
-from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.interfaces.plugin.device_repository import DeviceRepository
-from netimate.models.device import Device
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +54,12 @@ class Application(ApplicationInterface):
         self._command_executor_service = command_executor_service or CommandExecutorService(
             registry, settings, template_provider, runner
         )
-        self._snapshot_service = snapshot_service or SnapshotService(
-            self._command_executor_service
+        self._snapshot_service = snapshot_service or SnapshotService(self._command_executor_service)
+
+    def get_device_command(self, name: str):
+        """Return a device command instance for the given command name."""
+        return self._registry.get_device_command(name)(
+            self._template_provider, self._settings.plugin_configs.get(name)
         )
 
     def get_device_repository(self) -> DeviceRepository:

--- a/netimate/application/application.py
+++ b/netimate/application/application.py
@@ -61,33 +61,10 @@ class Application(ApplicationInterface):
             self._command_executor_service
         )
 
-    def get_template_provider(self) -> TemplateProviderInterface:
-        """Return the singleton TemplateProvider injected at startup."""
-        return self._template_provider
-
-    def get_log_level(self) -> str:
-        """Return the current log level from settings."""
-        return self._settings.log_level
-
-    def get_settings(self) -> SettingsInterface:
-        """Return the application settings instance."""
-        return self._settings
-
     def get_device_repository(self) -> DeviceRepository:
         """Return an instance of the configured device repository plugin."""
         repo_cls = self._registry.get_device_repository(self._settings.device_repo)
         return repo_cls(self._settings.plugin_configs.get(self._settings.device_repo))
-
-    def get_protocol(self, name: str, device: Device) -> ConnectionProtocol:
-        """Return a protocol instance for the given name and device."""
-        protocol_cls = self._registry.get_protocol(name)
-        return protocol_cls(device, self._settings.plugin_configs.get(name))
-
-    def get_device_command(self, name: str):
-        """Return a device command instance for the given command name."""
-        return self._registry.get_device_command(name)(
-            self._template_provider, self._settings.plugin_configs.get(name)
-        )
 
     def expand_device_names(self, names: List[str]) -> List[str]:
         """

--- a/netimate/application/command_executor_service.py
+++ b/netimate/application/command_executor_service.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MPL-2.0
+from typing import Dict, List, Tuple
+from netimate.interfaces.core.registry import PluginRegistryInterface
+from netimate.interfaces.infrastructure.settings import SettingsInterface
+from netimate.interfaces.infrastructure.template_provider import TemplateProviderInterface
+from netimate.interfaces.core.runner import RunnerInterface
+from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
+from netimate.interfaces.plugin.device_repository import DeviceRepository
+from netimate.models.device import Device
+
+
+class CommandExecutorService:
+    def __init__(
+        self,
+        registry: PluginRegistryInterface,
+        settings: SettingsInterface,
+        template_provider: TemplateProviderInterface,
+        runner: RunnerInterface,
+    ):
+        self._registry = registry
+        self._settings = settings
+        self._template_provider = template_provider
+        self._runner = runner
+
+    async def run(self, device_names: List[str], command_name: str) -> Dict[str, str]:
+        """
+        Run a command on the given list of device names.
+        Note: device_names should be pre-expanded and must correspond exactly to device names.
+        """
+        repository_cls = self._registry.get_device_repository(self._settings.device_repo)
+        repository: DeviceRepository = repository_cls(
+            self._settings.plugin_configs.get(self._settings.device_repo)
+        )
+        devices = repository.list_devices()
+
+        selected_devices = [d for d in devices if d.name in device_names]
+        if len(selected_devices) != len(device_names):
+            raise ValueError("One or more device names not found.")
+
+        command_cls = self._registry.get_device_command(command_name)
+        command = command_cls(self._template_provider)
+
+        device_protocol_pairs: List[Tuple[Device, ConnectionProtocol]] = []
+        for device in selected_devices:
+            protocol_name = device.protocol
+            protocol_cls = self._registry.get_protocol(protocol_name)
+            protocol_config = self._settings.plugin_configs.get(protocol_name, {})
+            protocol = protocol_cls(protocol_config)
+            device_protocol_pairs.append((device, protocol))
+
+        results = await self._runner.run(device_protocol_pairs, command)
+        return {r["device"]: r["result"] for r in results}

--- a/netimate/application/command_executor_service.py
+++ b/netimate/application/command_executor_service.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
 from typing import Dict, List, Tuple
+
 from netimate.interfaces.core.registry import PluginRegistryInterface
+from netimate.interfaces.core.runner import RunnerInterface
 from netimate.interfaces.infrastructure.settings import SettingsInterface
 from netimate.interfaces.infrastructure.template_provider import TemplateProviderInterface
-from netimate.interfaces.core.runner import RunnerInterface
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.interfaces.plugin.device_repository import DeviceRepository
 from netimate.models.device import Device
@@ -44,7 +45,7 @@ class CommandExecutorService:
         for device in selected_devices:
             protocol_name = device.protocol
             protocol_cls = self._registry.get_protocol(protocol_name)
-            protocol_config = self._settings.plugin_configs.get(protocol_name, {})
+            protocol_config: str | Dict = self._settings.plugin_configs.get(protocol_name, {})
             protocol = protocol_cls(protocol_config)
             device_protocol_pairs.append((device, protocol))
 

--- a/netimate/application/snapshot_service.py
+++ b/netimate/application/snapshot_service.py
@@ -7,11 +7,7 @@ from netimate.application.command_executor_service import CommandExecutorService
 
 
 class SnapshotService:
-    def __init__(
-        self,
-        executor: CommandExecutorService,
-        snapshot_dir: Path = Path("snapshots")
-    ):
+    def __init__(self, executor: CommandExecutorService, snapshot_dir: Path = Path("snapshots")):
         self._executor = executor
         self._snapshot_dir = snapshot_dir
 

--- a/netimate/application/snapshot_service.py
+++ b/netimate/application/snapshot_service.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MPL-2.0
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from netimate.application.command_executor_service import CommandExecutorService
+
+
+class SnapshotService:
+    def __init__(
+        self,
+        executor: CommandExecutorService,
+        snapshot_dir: Path = Path("snapshots")
+    ):
+        self._executor = executor
+        self._snapshot_dir = snapshot_dir
+
+    async def snapshot(self, device_names: List[str]) -> Dict[str, str]:
+        results = await self._executor.run(device_names, "show-running-config")
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self._snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+        for device, output in results.items():
+            file_path = self._snapshot_dir / f"{device}_running_config_{timestamp}.txt"
+            if isinstance(output, dict) and "config_lines" in output:
+                file_path.write_text("\n".join(output["config_lines"]))
+            else:
+                file_path.write_text(str(output))
+
+        return results

--- a/netimate/composition.py
+++ b/netimate/composition.py
@@ -65,7 +65,7 @@ def composition_root() -> ApplicationInterface:
 
     # 3. Create dependencies
     template_provider = FileSystemTemplateProvider(settings.template_paths)
-    runner = Runner(registry, settings.plugin_configs)
+    runner = Runner(settings.plugin_configs)
 
     # 4. Initialise application
     app = Application(registry, settings, runner, template_provider)

--- a/netimate/core/runner.py
+++ b/netimate/core/runner.py
@@ -19,8 +19,7 @@ class Runner(RunnerInterface):
     Selects appropriate runner per device using RunnerSelector.
     """
 
-    def __init__(self, registry: PluginRegistry, plugin_configs: Dict[str, Any]):
-        self.registry = registry
+    def __init__(self, plugin_configs: Dict[str, Any]):
         self.plugin_configs = plugin_configs
 
     async def run(self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand) -> (

--- a/netimate/core/runner.py
+++ b/netimate/core/runner.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 import asyncio
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from netimate.core.plugin_engine.plugin_registry import PluginRegistry
 from netimate.errors import NetimateError, RunnerError
 from netimate.interfaces.core.runner import RunnerInterface
+from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.interfaces.plugin.device_command import DeviceCommand
 from netimate.models.device import Device
 
@@ -22,19 +23,25 @@ class Runner(RunnerInterface):
         self.registry = registry
         self.plugin_configs = plugin_configs
 
-    async def run(self, devices: List[Device], command: DeviceCommand) -> List[dict[str, Any]]:
+    async def run(self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand) -> (
+            List)[dict[str, Any]]:
         """
-        Executes the command on all devices concurrently.
+        Executes the command on all devices concurrently using their associated protocol instances.
 
         Returns:
             A list of results (or errors) per device.
         """
-        tasks = [self._run_on_device(device, command) for device in devices]
+        tasks = [
+            self._run_on_device(device, protocol, command)
+            for device, protocol in device_protocols
+        ]
         return await asyncio.gather(*tasks)
 
-    async def _run_on_device(self, device: Device, command: DeviceCommand) -> Dict[str, Any]:
+    async def _run_on_device(
+            self, device: Device, protocol: ConnectionProtocol, command: DeviceCommand
+    ) -> Dict[str, Any]:
         """
-        Execute *command* on *device* and return a structured per‑device result.
+        Execute *command* on *device* using the provided *protocol* instance and return a structured per‑device result.
 
         The method guarantees that no third‑party exceptions leak; any unexpected
         error is wrapped as ``RunnerError``.  The shape of the returned dict is::
@@ -54,10 +61,6 @@ class Runner(RunnerInterface):
         )
 
         try:
-            plugin_settings = self.plugin_configs.get(device.protocol, {})
-            protocol_cls = self.registry.get_protocol(device.protocol)
-            protocol = protocol_cls(device, plugin_settings)
-
             await protocol.connect()
             logger.debug("Connected to %s", device.host)
 

--- a/netimate/core/runner.py
+++ b/netimate/core/runner.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Tuple
 
-from netimate.core.plugin_engine.plugin_registry import PluginRegistry
 from netimate.errors import NetimateError, RunnerError
 from netimate.interfaces.core.runner import RunnerInterface
 from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
@@ -22,8 +21,9 @@ class Runner(RunnerInterface):
     def __init__(self, plugin_configs: Dict[str, Any]):
         self.plugin_configs = plugin_configs
 
-    async def run(self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand) -> (
-            List)[dict[str, Any]]:
+    async def run(
+        self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand
+    ) -> (List)[dict[str, Any]]:
         """
         Executes the command on all devices concurrently using their associated protocol instances.
 
@@ -31,13 +31,12 @@ class Runner(RunnerInterface):
             A list of results (or errors) per device.
         """
         tasks = [
-            self._run_on_device(device, protocol, command)
-            for device, protocol in device_protocols
+            self._run_on_device(device, protocol, command) for device, protocol in device_protocols
         ]
         return await asyncio.gather(*tasks)
 
     async def _run_on_device(
-            self, device: Device, protocol: ConnectionProtocol, command: DeviceCommand
+        self, device: Device, protocol: ConnectionProtocol, command: DeviceCommand
     ) -> Dict[str, Any]:
         """
         Execute *command* on *device* using the provided *protocol* instance and return a structured per‑device result.

--- a/netimate/interfaces/application/application.py
+++ b/netimate/interfaces/application/application.py
@@ -2,11 +2,6 @@
 from abc import abstractmethod
 from typing import Dict, List, Protocol
 
-from netimate.interfaces.infrastructure.settings import SettingsInterface
-from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
-from netimate.interfaces.plugin.device_repository import DeviceRepository
-from netimate.models.device import Device
-
 
 class ApplicationInterface(Protocol):  # pragma: no cover
     """

--- a/netimate/interfaces/application/application.py
+++ b/netimate/interfaces/application/application.py
@@ -17,24 +17,6 @@ class ApplicationInterface(Protocol):  # pragma: no cover
     """
 
     @abstractmethod
-    def get_log_level(self) -> str: ...
-
-    @abstractmethod
-    def get_settings(self) -> SettingsInterface:
-        """Return the application settings object."""
-        ...
-
-    @abstractmethod
-    def get_device_repository(self) -> DeviceRepository:
-        """Return the currently active device repository."""
-        ...
-
-    @abstractmethod
-    def get_protocol(self, name: str, device: Device) -> ConnectionProtocol:
-        """Return the protocol implementation by name."""
-        ...
-
-    @abstractmethod
     def list(self, key: str, site: str | None = None) -> List[str]:
         """
         Return a formatted string representation for the requested list.

--- a/netimate/interfaces/core/runner.py
+++ b/netimate/interfaces/core/runner.py
@@ -8,8 +8,9 @@ engine responsible for applying a :class:`DeviceCommand` across one or many
 results.
 """
 
-from typing import Any, List, Protocol
+from typing import Any, List, Protocol, Tuple
 
+from netimate.interfaces.plugin.connection_protocol import ConnectionProtocol
 from netimate.interfaces.plugin.device_command import DeviceCommand
 from netimate.models.device import Device
 
@@ -26,4 +27,5 @@ class RunnerInterface(Protocol):
        view (CLI/Shell) can render.
     """
 
-    async def run(self, devices: List[Device], command: DeviceCommand) -> List[dict[str, Any]]: ...
+    async def run(self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand) -> List[
+        dict[str, Any]]: ...

--- a/netimate/interfaces/core/runner.py
+++ b/netimate/interfaces/core/runner.py
@@ -27,5 +27,6 @@ class RunnerInterface(Protocol):
        view (CLI/Shell) can render.
     """
 
-    async def run(self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand) -> List[
-        dict[str, Any]]: ...
+    async def run(
+        self, device_protocols: List[Tuple[Device, ConnectionProtocol]], command: DeviceCommand
+    ) -> List[dict[str, Any]]: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,10 @@ import pytest
 import yaml
 
 from netimate.application.application import Application
+from netimate.interfaces.core.registry import PluginRegistryInterface
+from netimate.interfaces.core.runner import RunnerInterface
+from netimate.interfaces.infrastructure.settings import SettingsInterface
+from netimate.interfaces.infrastructure.template_provider import TemplateProviderInterface
 from netimate.models.device import Device
 
 
@@ -90,3 +94,41 @@ def app_with_mock_command_repo_registry(temp_device_and_settings_files):
         runner=mock_runner,
         template_provider=MagicMock(),
     )
+
+
+@pytest.fixture
+def fake_device():
+    return Device(name="r1", site="siteA", os="ios", protocol="ssh")
+
+
+@pytest.fixture
+def fake_devices():
+    return [
+        Device(name="r1", site="siteA", os="ios", protocol="ssh"),
+        Device(name="r2", site="siteA", os="ios", protocol="ssh"),
+    ]
+
+
+@pytest.fixture
+def mock_registry():
+    registry = MagicMock(spec=PluginRegistryInterface)
+    return registry
+
+
+@pytest.fixture
+def mock_runner():
+    return AsyncMock(spec=RunnerInterface)
+
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock(spec=SettingsInterface)
+    settings.device_repo = "fake_repo"
+    settings.plugin_configs = {}
+    return settings
+
+
+@pytest.fixture
+def mock_template_provider():
+    return MagicMock(spec=TemplateProviderInterface)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,19 +97,6 @@ def app_with_mock_command_repo_registry(temp_device_and_settings_files):
 
 
 @pytest.fixture
-def fake_device():
-    return Device(name="r1", site="siteA", os="ios", protocol="ssh")
-
-
-@pytest.fixture
-def fake_devices():
-    return [
-        Device(name="r1", site="siteA", os="ios", protocol="ssh"),
-        Device(name="r2", site="siteA", os="ios", protocol="ssh"),
-    ]
-
-
-@pytest.fixture
 def mock_registry():
     registry = MagicMock(spec=PluginRegistryInterface)
     return registry
@@ -131,4 +118,3 @@ def mock_settings():
 @pytest.fixture
 def mock_template_provider():
     return MagicMock(spec=TemplateProviderInterface)
-

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -26,4 +26,4 @@ def test_cli_happy_path(temp_device_and_settings_files):
         env=env,
     )
 
-    assert "---\n[r1]\n{'raw': 'echo test'}\n" in result.stdout
+    assert "---\n[r1]\necho test\n" in result.stdout

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -26,4 +26,4 @@ def test_cli_happy_path(temp_device_and_settings_files):
         env=env,
     )
 
-    assert "---\n[r1]\necho test\n" in result.stdout
+    assert "---\n[r1]\n{'raw': 'echo test'}\n" in result.stdout

--- a/tests/integration/test_shell_commands.py
+++ b/tests/integration/test_shell_commands.py
@@ -119,7 +119,7 @@ def test_shell_snapshot_command(temp_device_and_settings_files):
 
     fixed_time = datetime.datetime(2024, 1, 1, 12, 0, 0)
     with (
-        mock.patch("netimate.application.application.datetime") as mock_datetime,
+        mock.patch("netimate.application.snapshot_service.datetime") as mock_datetime,
         mock.patch("netimate.application.application.Path.write_text"),
     ):
         mock_datetime.datetime.now.return_value = fixed_time
@@ -254,7 +254,7 @@ def test_shell_diff_snapshots_command(temp_device_and_settings_files):
 
     fixed_time = datetime.datetime(2024, 1, 1, 12, 0, 0)
 
-    with mock.patch("netimate.application.application.datetime") as mock_datetime:
+    with mock.patch("netimate.application.snapshot_service.datetime") as mock_datetime:
         mock_datetime.datetime.now.return_value = fixed_time
         mock_datetime.datetime.strftime = datetime.datetime.strftime
 

--- a/tests/unit/test_application/test_command_executor_service.py
+++ b/tests/unit/test_application/test_command_executor_service.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MPL-2.0
+from unittest.mock import MagicMock
+
+import pytest
+
+from netimate.application.command_executor_service import CommandExecutorService
+
+
+@pytest.mark.asyncio
+async def test_run_valid_command(
+    temp_device_and_settings_files,
+    mock_runner,
+    mock_registry,
+    mock_settings,
+    mock_template_provider,
+):
+    devices, _, _ = temp_device_and_settings_files
+    mock_command = MagicMock()
+    mock_registry.get_device_repository.return_value = MagicMock(
+        return_value=MagicMock(list_devices=MagicMock(return_value=devices))
+    )
+    mock_registry.get_device_command.return_value = MagicMock(return_value=mock_command)
+    mock_runner.run.return_value = [
+        {"device": "r1", "result": "ok"},
+        {"device": "r2", "result": "ok"},
+    ]
+
+    svc = CommandExecutorService(mock_registry, mock_settings, mock_template_provider, mock_runner)
+    result = await svc.run(["r1", "r2"], "some-command")
+
+    assert result == {"r1": "ok", "r2": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_run_with_missing_device(
+    temp_device_and_settings_files,
+    mock_runner,
+    mock_registry,
+    mock_settings,
+    mock_template_provider,
+):
+    devices, _, _ = temp_device_and_settings_files
+    mock_registry.get_device_repository.return_value = MagicMock(
+        return_value=MagicMock(list_devices=MagicMock(return_value=devices))
+    )
+    svc = CommandExecutorService(mock_registry, mock_settings, mock_template_provider, mock_runner)
+
+    with pytest.raises(ValueError):
+        await svc.run(["r1", "does-not-exist"], "some-command")

--- a/tests/unit/test_application/test_snapshot_service.py
+++ b/tests/unit/test_application/test_snapshot_service.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MPL-2.0
+import pytest
+
+from netimate.application.snapshot_service import SnapshotService
+
+
+@pytest.mark.asyncio
+async def test_snapshot_saves_output(tmp_path, mock_runner):
+    class DummyCommand:
+        pass
+
+    mock_runner.run.return_value = {"r1": {"config_lines": ["line1", "line2"]}}
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_service = SnapshotService(mock_runner, snapshot_dir=snapshot_dir)
+
+    result = await snapshot_service.snapshot(["r1"])
+    assert "r1" in result
+    files = list(snapshot_dir.glob("r1_running_config_*.txt"))
+    assert files
+    assert files[0].read_text() == "line1\nline2"

--- a/tests/unit/test_core/test_runner.py
+++ b/tests/unit/test_core/test_runner.py
@@ -43,9 +43,10 @@ async def test_runner_handles_device_error(temp_device_and_settings_files):
     mock_command.return_value = mock_command_instance
     mock_command.plugin_name = "echo-test"
 
-    runner = Runner(registry=registry, plugin_configs={})
+    runner = Runner(plugin_configs={})
 
-    results = await runner.run(device, mock_command)
+    protocol = FailingAsyncProtocol(device[0], {})
+    results = await runner.run([(device[0], protocol)], mock_command)
     result = results[0]
 
     assert result["success"] is False


### PR DESCRIPTION
This PR modularises the Application layer by introducing two dedicated services:
	•	CommandExecutorService: handles device name resolution, plugin loading, and command execution
	•	SnapshotService: coordinates snapshot saving using the executor

✅ Key Changes:
	•	Application now instantiates or accepts injected services (SnapshotService, CommandExecutorService)
	•	Runner updated to receive (device, protocol) pairs (removes plugin registry dependency)
	•	Snapshot logic removed from Application and delegated to service
	•	Tests added for both services with real fixtures

This completes the first step in decoupling application logic from the CLI interface and prepares the ground for additional services (e.g., diagnostics, listing).
